### PR TITLE
Add utilities (v1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
 				"css-loader": "^6.10.0",
 				"html-webpack-plugin": "^5.6.0",
 				"jest-environment-jsdom": "^29.7.0",
+				"postcss": "^8.4.38",
+				"postcss-loader": "^8.1.1",
 				"prettier": "3.2.5",
 				"style-loader": "^3.3.4",
 				"terser-webpack-plugin": "^5.3.10",
@@ -5074,6 +5076,50 @@
 			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
 			"dev": true
 		},
+		"node_modules/cosmiconfig": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
+			"integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
+			"dev": true,
+			"dependencies": {
+				"env-paths": "^2.2.1",
+				"import-fresh": "^3.3.0",
+				"js-yaml": "^4.1.0",
+				"parse-json": "^5.2.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/d-fischer"
+			},
+			"peerDependencies": {
+				"typescript": ">=4.9.5"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/cosmiconfig/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true
+		},
+		"node_modules/cosmiconfig/node_modules/js-yaml": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+			"dev": true,
+			"dependencies": {
+				"argparse": "^2.0.1"
+			},
+			"bin": {
+				"js-yaml": "bin/js-yaml.js"
+			}
+		},
 		"node_modules/create-jest": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
@@ -5749,6 +5795,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/env-paths": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+			"integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/envinfo": {
@@ -9424,6 +9479,15 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
+		"node_modules/jiti": {
+			"version": "1.21.0",
+			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+			"integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
+			"dev": true,
+			"bin": {
+				"jiti": "bin/jiti.js"
+			}
+		},
 		"node_modules/js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10568,9 +10632,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.4.35",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.35.tgz",
-			"integrity": "sha512-u5U8qYpBCpN13BsiEB0CbR1Hhh4Gc0zLFuedrHJKMctHCHAGrMdG0PRM/KErzAL3CU6/eckEtmHNB3x6e3c0vA==",
+			"version": "8.4.38",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+			"integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
 			"dev": true,
 			"funding": [
 				{
@@ -10589,11 +10653,75 @@
 			"dependencies": {
 				"nanoid": "^3.3.7",
 				"picocolors": "^1.0.0",
-				"source-map-js": "^1.0.2"
+				"source-map-js": "^1.2.0"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
+		},
+		"node_modules/postcss-loader": {
+			"version": "8.1.1",
+			"resolved": "https://registry.npmjs.org/postcss-loader/-/postcss-loader-8.1.1.tgz",
+			"integrity": "sha512-0IeqyAsG6tYiDRCYKQJLAmgQr47DX6N7sFSWvQxt6AcupX8DIdmykuk/o/tx0Lze3ErGHJEp5OSRxrelC6+NdQ==",
+			"dev": true,
+			"dependencies": {
+				"cosmiconfig": "^9.0.0",
+				"jiti": "^1.20.0",
+				"semver": "^7.5.4"
+			},
+			"engines": {
+				"node": ">= 18.12.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/webpack"
+			},
+			"peerDependencies": {
+				"@rspack/core": "0.x || 1.x",
+				"postcss": "^7.0.0 || ^8.0.1",
+				"webpack": "^5.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@rspack/core": {
+					"optional": true
+				},
+				"webpack": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/postcss-loader/node_modules/lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"dev": true,
+			"dependencies": {
+				"yallist": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/postcss-loader/node_modules/semver": {
+			"version": "7.6.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+			"integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+			"dev": true,
+			"dependencies": {
+				"lru-cache": "^6.0.0"
+			},
+			"bin": {
+				"semver": "bin/semver.js"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/postcss-loader/node_modules/yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true
 		},
 		"node_modules/postcss-modules-extract-imports": {
 			"version": "3.0.0",
@@ -11603,9 +11731,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+			"integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
 		"css-loader": "^6.10.0",
 		"html-webpack-plugin": "^5.6.0",
 		"jest-environment-jsdom": "^29.7.0",
+		"postcss": "^8.4.38",
+		"postcss-loader": "^8.1.1",
 		"prettier": "3.2.5",
 		"style-loader": "^3.3.4",
 		"terser-webpack-plugin": "^5.3.10",

--- a/src/utilities/__test__/check-null-undefined-empty.test.js
+++ b/src/utilities/__test__/check-null-undefined-empty.test.js
@@ -1,0 +1,71 @@
+'use strict'
+
+import { checkNullUndefinedEmpty } from '../check-null-undefined-empty.js'
+
+describe('checkNullUndefinedEmpty', () => {
+	describe('Happy Path', () => {
+		it('should return false when given a non-empty string', () => {
+			const result = checkNullUndefinedEmpty('Hello')
+			expect(result).toBe(false)
+		})
+
+		it('should return true when given an empty string', () => {
+			const result = checkNullUndefinedEmpty('')
+			expect(result).toBe(true)
+		})
+
+		it('should return true when given undefined', () => {
+			const result = checkNullUndefinedEmpty(undefined)
+			expect(result).toBe(true)
+		})
+
+		it('should return true when given null', () => {
+			const result = checkNullUndefinedEmpty(null)
+			expect(result).toBe(true)
+		})
+
+		it('should return true when given an empty array', () => {
+			const result = checkNullUndefinedEmpty([])
+			expect(result).toBe(true)
+		})
+	})
+
+	describe('Edge Cases', () => {
+		it('should return false when given a number', () => {
+			const result = checkNullUndefinedEmpty(123)
+			expect(result).toBe(false)
+		})
+
+		it('should return false when given a boolean', () => {
+			const result = checkNullUndefinedEmpty(true)
+			expect(result).toBe(false)
+		})
+
+		it('should return false when given a function', () => {
+			const result = checkNullUndefinedEmpty(() => {})
+			expect(result).toBe(false)
+		})
+
+		it('should return false when given an object', () => {
+			const result = checkNullUndefinedEmpty({})
+			expect(result).toBe(false)
+		})
+	})
+
+	describe('Others', () => {
+		it('should return false when given an array with at least one non-null/undefined value', () => {
+			const result = checkNullUndefinedEmpty([1, null, undefined])
+			expect(result).toBe(false)
+		})
+
+		it('should return false when given an array with only null and undefined values', () => {
+			const result = checkNullUndefinedEmpty([null, undefined])
+			expect(result).toBe(false)
+		})
+
+		it('should return true when given a string with only whitespace characters', () => {
+			const result = checkNullUndefinedEmpty('   ')
+			expect(result).toBe(true)
+		})
+	})
+})

--- a/src/utilities/__test__/set-attributes.test.js
+++ b/src/utilities/__test__/set-attributes.test.js
@@ -1,14 +1,14 @@
 'use strict'
 
 import { JSDOM } from 'jsdom'
-import { setElementAttributes } from '../set-element-attributes.js'
+import { setAttributes } from '../set-element-attributes.js'
 
 const dom = new JSDOM('<!DOCTYPE html>')
 global.window = dom.window
 global.document = window.document
 global.HTMLElement = window.HTMLElement
 
-describe('setElementAttributes', () => {
+describe('setAttributes', () => {
 	it('should set valid attributes on a valid HTML element', () => {
 		const element = document.createElement('div')
 		const attributes = {
@@ -17,7 +17,7 @@ describe('setElementAttributes', () => {
 			style: 'color: blue;'
 		}
 
-		const result = setElementAttributes(element, attributes)
+		const result = setAttributes(element, attributes)
 
 		expect(result).toEqual(true)
 		expect(element.getAttribute('id')).toBe('sample-div')
@@ -35,7 +35,7 @@ describe('setElementAttributes', () => {
 			style: 'color: red;'
 		}
 
-		const result = setElementAttributes(null, attributes)
+		const result = setAttributes(null, attributes)
 		expect(spyConsoleError).toHaveBeenCalledWith(
 			'The element must be provided.'
 		)
@@ -51,7 +51,7 @@ describe('setElementAttributes', () => {
 		const element = document.createElement('div')
 		const attributes = {}
 
-		const result = setElementAttributes(element, attributes)
+		const result = setAttributes(element, attributes)
 
 		expect(result).toEqual(false)
 		expect(spyConsoleError).toHaveBeenCalledWith(
@@ -64,7 +64,7 @@ describe('setElementAttributes', () => {
 		const attributes = null
 		const consoleErrorSpy = jest.spyOn(console, 'error')
 
-		const result = setElementAttributes(element, attributes)
+		const result = setAttributes(element, attributes)
 
 		expect(result).toBe(false)
 		expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -81,7 +81,7 @@ describe('setElementAttributes', () => {
 			style: 'color: red;'
 		}
 
-		const result = setElementAttributes(element, attributes)
+		const result = setAttributes(element, attributes)
 
 		expect(result).toBe(false)
 	})
@@ -94,7 +94,7 @@ describe('setElementAttributes', () => {
 			'data-123': '123'
 		}
 
-		const result = setElementAttributes(element, attributes)
+		const result = setAttributes(element, attributes)
 
 		expect(result).toBe(true)
 		expect(element.getAttribute('data-special')).toBe('special')

--- a/src/utilities/__test__/set-element-attributes.test.js
+++ b/src/utilities/__test__/set-element-attributes.test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+import { JSDOM } from 'jsdom'
+import { setElementAttributes } from '../set-element-attributes.js'
+
+const dom = new JSDOM('<!DOCTYPE html>')
+global.window = dom.window
+global.document = window.document
+global.HTMLElement = window.HTMLElement
+
+describe('setElementAttributes', () => {
+	it('should set valid attributes on a valid HTML element', () => {
+		const element = document.createElement('div')
+		const attributes = {
+			id: 'sample-div',
+			class: 'container',
+			style: 'color: blue;'
+		}
+
+		const result = setElementAttributes(element, attributes)
+
+		expect(result).toEqual(true)
+		expect(element.getAttribute('id')).toBe('sample-div')
+		expect(element.getAttribute('class')).toBe('container')
+		expect(element.getAttribute('style')).toBe('color: blue;')
+	})
+
+	it('should return false when element is not provided', () => {
+		const spyConsoleError = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {})
+		const attributes = {
+			id: 'sample-div',
+			class: 'container',
+			style: 'color: red;'
+		}
+
+		const result = setElementAttributes(null, attributes)
+		expect(spyConsoleError).toHaveBeenCalledWith(
+			'The element must be provided.'
+		)
+		expect(result).toBe(false)
+
+		spyConsoleError.mockRestore()
+	})
+
+	it('should not set attributes on a valid HTML element and an empty object', () => {
+		const spyConsoleError = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => {})
+		const element = document.createElement('div')
+		const attributes = {}
+
+		const result = setElementAttributes(element, attributes)
+
+		expect(result).toEqual(false)
+		expect(spyConsoleError).toHaveBeenCalledWith(
+			'The attributes must be provided.'
+		)
+	})
+
+	it('should log an error message when attributes are not provided', () => {
+		const element = document.createElement('div')
+		const attributes = null
+		const consoleErrorSpy = jest.spyOn(console, 'error')
+
+		const result = setElementAttributes(element, attributes)
+
+		expect(result).toBe(false)
+		expect(consoleErrorSpy).toHaveBeenCalledWith(
+			'The attributes must be provided.'
+		)
+		consoleErrorSpy.mockRestore()
+	})
+
+	it('should not set attributes on a non-HTML element and a non-empty object', () => {
+		const element = 'not an HTML element'
+		const attributes = {
+			id: 'sample-div',
+			class: 'container',
+			style: 'color: red;'
+		}
+
+		const result = setElementAttributes(element, attributes)
+
+		expect(result).toBe(false)
+	})
+
+	it('should set attributes with special characters correctly when provided with a valid HTML element and a non-empty object', () => {
+		const element = document.createElement('div')
+		const attributes = {
+			'data-special': 'special',
+			'data-test': 'test',
+			'data-123': '123'
+		}
+
+		const result = setElementAttributes(element, attributes)
+
+		expect(result).toBe(true)
+		expect(element.getAttribute('data-special')).toBe('special')
+		expect(element.getAttribute('data-test')).toBe('test')
+		expect(element.getAttribute('data-123')).toBe('123')
+	})
+})

--- a/src/utilities/check-null-undefined-empty.js
+++ b/src/utilities/check-null-undefined-empty.js
@@ -1,0 +1,19 @@
+'use strict'
+
+function checkNullUndefinedEmpty(value) {
+	if (value === null || value === undefined) {
+		return true
+	}
+
+	if (typeof value === 'string' && value.trim() === '') {
+		return true
+	}
+
+	if (Array.isArray(value) && value.length === 0) {
+		return true
+	}
+
+	return false
+}
+
+export { checkNullUndefinedEmpty }

--- a/src/utilities/set-attributes.js
+++ b/src/utilities/set-attributes.js
@@ -1,0 +1,33 @@
+'use strict'
+
+function setAttributes(element, attributes) {
+	if (!element) {
+		console.error('The element must be provided.')
+		return false
+	}
+
+	if (!attributes || Object.keys(attributes).length === 0) {
+		console.error('The attributes must be provided.')
+		return false
+	}
+
+	if (!(element instanceof HTMLElement)) {
+		const notValidElement = 'The element provided is not a valid HTML element.'
+		console.error(notValidElement)
+		return false
+	}
+
+	if (typeof attributes !== 'object') {
+		const notValidAttributes = 'The attributes provided are not a valid object.'
+		console.error(notValidAttributes)
+		return false
+	}
+
+	Object.entries(attributes).forEach(([key, value]) => {
+		element.setAttribute(key, value)
+	})
+
+	return true
+}
+
+export { setElementAttributes }

--- a/src/utilities/set-attributes.js
+++ b/src/utilities/set-attributes.js
@@ -30,4 +30,4 @@ function setAttributes(element, attributes) {
 	return true
 }
 
-export { setElementAttributes }
+export { setAttributes }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ module.exports = (env, argv) => ({
 			{
 				test: /\.css$/i,
 				exclude: /node_modules/,
-				use: ['style-loader', 'css-loader']
+				use: ['style-loader', 'css-loader', 'postcss-loader']
 			},
 			{
 				test: /\.(png|svg|jpg|jpeg|gif)$/i,


### PR DESCRIPTION
### Add utilities (v1)

#### Description:

- Adds set attributes utility for an HTML element for more convenient usage than the default `setAtrribute`
- Adds PostCSS processing for improved CSS handling
- Adds check if it is null, undefined, or empty utility

#### Changes:

- *No file has been modified in this changes*

#### Testing:

- [x] I have added unit tests for all new functionalities. 
- [x] I have performed a self-review of my code.
- [x] I have formatted the code according to the style guide.